### PR TITLE
Fix image size limits, caller context, and gallery auth

### DIFF
--- a/handler_gallery.go
+++ b/handler_gallery.go
@@ -33,6 +33,10 @@ func (h *galleryListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uid := h.userID(r.Context())
+	if uid == "" {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
 	slug := r.PathValue("slug")
 	if slug == "" {
 		writeError(w, http.StatusBadRequest, "slug required")

--- a/handler_gallery_test.go
+++ b/handler_gallery_test.go
@@ -99,6 +99,22 @@ func TestGalleryListHandler_EmptyGallery(t *testing.T) {
 	}
 }
 
+func TestGalleryListHandler_EmptyUserID(t *testing.T) {
+	store := newMemGalleryStore()
+	emptyUserID := func(ctx context.Context) string { return "" }
+	handler := lens.GalleryListHandler(store, emptyUserID)
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/agents/{slug}/gallery", handler)
+
+	req := httptest.NewRequest("GET", "/api/agents/bot/gallery", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
 }

--- a/image_store.go
+++ b/image_store.go
@@ -16,6 +16,9 @@ import (
 	"golang.org/x/image/draw"
 )
 
+// MaxImageSize is the maximum allowed image data size (20 MB).
+const MaxImageSize = 20 * 1024 * 1024
+
 // ImageStore handles saving and loading images from the filesystem.
 type ImageStore struct {
 	dir string
@@ -40,6 +43,9 @@ func validateID(id string) error {
 
 // Save writes image data to a new file and returns its ID.
 func (s *ImageStore) Save(data []byte) (string, error) {
+	if len(data) > MaxImageSize {
+		return "", fmt.Errorf("image data exceeds maximum size of %d bytes", MaxImageSize)
+	}
 	id := uuid.New().String()
 	path := filepath.Join(s.dir, id+".png")
 	if err := os.WriteFile(path, data, 0644); err != nil {
@@ -63,6 +69,9 @@ var thumbVariants = []struct {
 func (s *ImageStore) SaveWithID(id string, data []byte) error {
 	if err := validateID(id); err != nil {
 		return err
+	}
+	if len(data) > MaxImageSize {
+		return fmt.Errorf("image data exceeds maximum size of %d bytes", MaxImageSize)
 	}
 	path := filepath.Join(s.dir, id+".png")
 	if err := os.WriteFile(path, data, 0644); err != nil {

--- a/image_store_test.go
+++ b/image_store_test.go
@@ -285,6 +285,39 @@ func TestImageStore_BackfillThumbnails(t *testing.T) {
 	}
 }
 
+func TestImageStore_Save_RejectsOversizedData(t *testing.T) {
+	dir := t.TempDir()
+	store := mustNewImageStore(t, dir)
+
+	oversized := make([]byte, lens.MaxImageSize+1)
+	_, err := store.Save(oversized)
+	if err == nil {
+		t.Error("expected error for oversized image data")
+	}
+}
+
+func TestImageStore_SaveWithID_RejectsOversizedData(t *testing.T) {
+	dir := t.TempDir()
+	store := mustNewImageStore(t, dir)
+
+	oversized := make([]byte, lens.MaxImageSize+1)
+	err := store.SaveWithID("test-id", oversized)
+	if err == nil {
+		t.Error("expected error for oversized image data")
+	}
+}
+
+func TestImageStore_Save_AcceptsMaxSize(t *testing.T) {
+	dir := t.TempDir()
+	store := mustNewImageStore(t, dir)
+
+	data := make([]byte, lens.MaxImageSize)
+	_, err := store.Save(data)
+	if err != nil {
+		t.Errorf("expected save to succeed at max size: %v", err)
+	}
+}
+
 func TestImageStore_SaveWithID_RejectsPathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	store := mustNewImageStore(t, dir)

--- a/prompt_merge.go
+++ b/prompt_merge.go
@@ -50,7 +50,7 @@ func NewPromptMerger(generate tool.TextGenerator, config *ImageGenConfig) *Promp
 
 // MergePrompt intelligently merges baseline, agent system prompt, recent conversation,
 // and scene into a single image generation prompt.
-func (m *PromptMerger) MergePrompt(systemPrompt string, recentMessages []Message, scene string) (string, error) {
+func (m *PromptMerger) MergePrompt(ctx context.Context, systemPrompt string, recentMessages []Message, scene string) (string, error) {
 	if m.config == nil {
 		return scene, fmt.Errorf("no config loaded")
 	}
@@ -75,7 +75,7 @@ func (m *PromptMerger) MergePrompt(systemPrompt string, recentMessages []Message
 	)
 	instruction := replacer.Replace(m.config.MergeInstruction)
 
-	result, err := m.generate(context.Background(), instruction)
+	result, err := m.generate(ctx, instruction)
 	if err != nil {
 		return "", fmt.Errorf("merge LLM call failed: %w", err)
 	}

--- a/prompt_merge_test.go
+++ b/prompt_merge_test.go
@@ -39,7 +39,7 @@ func TestPromptMerger_MergePrompt(t *testing.T) {
 		{Role: "assistant", Content: "hi there"},
 	}
 
-	result, err := merger.MergePrompt("you are helpful", messages, "a sunset")
+	result, err := merger.MergePrompt(context.Background(), "you are helpful", messages, "a sunset")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestPromptMerger_TrimsWhitespace(t *testing.T) {
 		MergeInstruction: "{scene}",
 	})
 
-	result, err := merger.MergePrompt("", nil, "test")
+	result, err := merger.MergePrompt(context.Background(), "", nil, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestPromptMerger_EmptyMessages(t *testing.T) {
 		MergeInstruction: "conv={conversation}",
 	})
 
-	_, err := merger.MergePrompt("", nil, "test")
+	_, err := merger.MergePrompt(context.Background(), "", nil, "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,6 @@
 package lens
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/google/uuid"
@@ -52,7 +51,7 @@ func submitImageTask(cfg *Config, ctx *tool.ToolContext, promptStr string) tool.
 			}
 		}
 
-		merged, err := cfg.PromptMerger.MergePrompt(ctx.SystemPrompt, recentMessages, promptStr)
+		merged, err := cfg.PromptMerger.MergePrompt(ctx.Ctx, ctx.SystemPrompt, recentMessages, promptStr)
 		if err == nil {
 			finalPrompt = merged
 		} else {
@@ -68,7 +67,7 @@ func submitImageTask(cfg *Config, ctx *tool.ToolContext, promptStr string) tool.
 		ImageID:        imageID,
 	}
 
-	_, err := cfg.TaskSubmitter.SubmitTask(context.Background(), NewImageTaskRequest(submission))
+	_, err := cfg.TaskSubmitter.SubmitTask(ctx.Ctx, NewImageTaskRequest(submission))
 	if err != nil {
 		slog.Error("failed to submit image task", "error", err, "image_id", imageID)
 		return tool.ToolResult{Content: "Error: failed to submit image generation task"}

--- a/tools_test.go
+++ b/tools_test.go
@@ -10,10 +10,12 @@ import (
 
 type mockTaskSubmitter struct {
 	lastReq *lens.TaskSubmitRequest
+	lastCtx context.Context
 }
 
 func (m *mockTaskSubmitter) SubmitTask(ctx context.Context, req *lens.TaskSubmitRequest) (*lens.TaskSubmission, error) {
 	m.lastReq = req
+	m.lastCtx = ctx
 	return &lens.TaskSubmission{TaskID: "task-1", Status: "queued"}, nil
 }
 
@@ -111,6 +113,28 @@ func TestTakePhotoTool_WithPromptMerger(t *testing.T) {
 	params := submitter.lastReq.Params.(*lens.ImageTaskSubmission)
 	if params.Prompt != "merged prompt" {
 		t.Errorf("Prompt = %q, want %q", params.Prompt, "merged prompt")
+	}
+}
+
+func TestTakePhotoTool_PropagatesCallerContext(t *testing.T) {
+	type ctxKey string
+	submitter := &mockTaskSubmitter{}
+	cfg := &lens.Config{TaskSubmitter: submitter}
+
+	td := lens.TakePhotoTool(cfg)
+	callerCtx := context.WithValue(context.Background(), ctxKey("trace"), "abc123")
+	ctx := &tool.ToolContext{
+		Ctx:    callerCtx,
+		UserID: "user-1",
+	}
+
+	td.Execute(ctx, map[string]any{"prompt": "test"})
+
+	if submitter.lastCtx == nil {
+		t.Fatal("expected context to be passed to SubmitTask")
+	}
+	if submitter.lastCtx.Value(ctxKey("trace")) != "abc123" {
+		t.Error("expected caller context to be propagated, not context.Background()")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1

- **Propagate caller context instead of `context.Background()`** in `submitImageTask` (tools.go:71) and `PromptMerger.MergePrompt` (prompt_merge.go:78), so cancellation signals and tracing propagate correctly through the image generation pipeline
- **Add 20 MB image size limit** (`MaxImageSize`) enforced in both `Save` and `SaveWithID` on `ImageStore`, preventing unbounded file writes
- **Validate empty userID** in `GalleryListHandler`, returning 401 Unauthorized when authentication is missing

## Test plan

- [x] `TestTakePhotoTool_PropagatesCallerContext` — verifies context values flow through to `SubmitTask`
- [x] `TestImageStore_Save_RejectsOversizedData` — rejects data exceeding 20 MB
- [x] `TestImageStore_SaveWithID_RejectsOversizedData` — rejects data exceeding 20 MB
- [x] `TestImageStore_Save_AcceptsMaxSize` — boundary test at exactly 20 MB
- [x] `TestGalleryListHandler_EmptyUserID` — returns 401 for empty user ID
- [x] All existing tests pass (`go test ./...`)